### PR TITLE
Fix up torch tile handling.

### DIFF
--- a/core/java/android/hardware/ITorchCallback.aidl
+++ b/core/java/android/hardware/ITorchCallback.aidl
@@ -22,9 +22,9 @@ package android.hardware;
  */
 oneway interface ITorchCallback {
      /**
-      * Called when the flashlight turns off unexpectedly.
+      * Called when the flashlight state changes
       */
-     void onTorchOff();
+     void onTorchStateChanged(boolean on);
 
      /**
       * Called when there is an error that turns the flashlight off.

--- a/packages/SystemUI/src/com/android/systemui/qs/tiles/FlashlightTile.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/tiles/FlashlightTile.java
@@ -38,11 +38,13 @@ public class FlashlightTile extends QSTile<QSTile.BooleanState> implements
             = new AnimationIcon(R.drawable.ic_signal_flashlight_disable_animation);
     private final TorchManager mTorchManager;
     private long mWasLastOn;
+    private boolean mTorchAvailable;
 
     public FlashlightTile(Host host) {
         super(host);
         mTorchManager = (TorchManager) mContext.getSystemService(Context.TORCH_SERVICE);
         mTorchManager.addListener(this);
+        mTorchAvailable = mTorchManager.isAvailable();
     }
 
     @Override
@@ -94,9 +96,7 @@ public class FlashlightTile extends QSTile<QSTile.BooleanState> implements
             }
         }
 
-        // Always show the tile when the flashlight is or was recently on. This is needed because
-        // the camera is not available while it is being used for the flashlight.
-        state.visible = mWasLastOn != 0 || mTorchManager.isAvailable();
+        state.visible = mWasLastOn != 0 || mTorchAvailable;
         state.label = mHost.getContext().getString(R.string.quick_settings_flashlight_label);
         final AnimationIcon icon = state.value ? mEnable : mDisable;
         icon.setAllowAnimation(arg instanceof UserBoolean && ((UserBoolean) arg).userInitiated);
@@ -117,8 +117,8 @@ public class FlashlightTile extends QSTile<QSTile.BooleanState> implements
     }
 
     @Override
-    public void onTorchOff() {
-        refreshState(UserBoolean.BACKGROUND_FALSE);
+    public void onTorchStateChanged(boolean on) {
+        refreshState(on ? UserBoolean.BACKGROUND_TRUE : UserBoolean.BACKGROUND_FALSE);
     }
 
     @Override
@@ -128,6 +128,7 @@ public class FlashlightTile extends QSTile<QSTile.BooleanState> implements
 
     @Override
     public void onTorchAvailabilityChanged(boolean available) {
+        mTorchAvailable = available;
         refreshState(mTorchManager.isTorchOn());
     }
 


### PR DESCRIPTION
- Keep it in sync with other torch invocations (e.g. via gesture)
- Only treat torch as 'unavailable' if another client (camera app) uses
  the camera, but not if torch itself opened it.

Change-Id: Ife9ae30ab48d491af70a5e23d1b2d123da60de3a